### PR TITLE
Add a test to ensure that datetimes cannot be used as deltas.

### DIFF
--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -376,3 +376,16 @@ def test_datetime_rectangle():
 
     fig, ax = plt.subplots()
     ax.add_patch(patch)
+
+
+def test_datetime_datetime_fails():
+    from datetime import datetime
+
+    start = datetime(2017, 1, 1, 0, 0, 0)
+    dt_delta = datetime(1970, 1, 5)    # Will be 5 days if units are done wrong
+
+    with pytest.raises(TypeError):
+        mpatches.Rectangle((start, 0), dt_delta, 1)
+
+    with pytest.raises(TypeError):
+        mpatches.Rectangle((0, start), 1, dt_delta)


### PR DESCRIPTION
New PR against the right branch. I guess github UI defaults to master instead the branch you are currently navigating when you do PR. Makes sense.